### PR TITLE
feat(plugins): support user custom plugin EnvironmentConfig

### DIFF
--- a/packages/plugin-main/src/index.ts
+++ b/packages/plugin-main/src/index.ts
@@ -1,6 +1,6 @@
 import type {EnvironmentConfig, RsbuildPlugin} from '@rsbuild/core'
 
-export const mainConfig: EnvironmentConfig = {
+export const defaultMainConfig: EnvironmentConfig = {
   source: {
     entry: {
       index: './src/main/index.ts',
@@ -47,11 +47,12 @@ export const mainConfig: EnvironmentConfig = {
 /**
  * plugin-main for rsbuild
  * */
-export const mainPlugin = (): RsbuildPlugin => ({
+export const mainPlugin = (customMainConfig?: EnvironmentConfig={}): RsbuildPlugin => ({
   name: 'electron-rsbuild:main',
   setup(api) {
     api.modifyEnvironmentConfig((config, {mergeEnvironmentConfig}) => {
       // TODO 更改 dev
+      const mainConfig = Object.assign({}, defaultMainConfig, customMainConfig)
       return mergeEnvironmentConfig(config, mainConfig)
     })
   },

--- a/packages/plugin-main/src/index.ts
+++ b/packages/plugin-main/src/index.ts
@@ -47,12 +47,12 @@ export const defaultMainConfig: EnvironmentConfig = {
 /**
  * plugin-main for rsbuild
  * */
-export const mainPlugin = (customMainConfig?: EnvironmentConfig={}): RsbuildPlugin => ({
+export const mainPlugin = (userMainConfig?: EnvironmentConfig={}): RsbuildPlugin => ({
   name: 'electron-rsbuild:main',
   setup(api) {
     api.modifyEnvironmentConfig((config, {mergeEnvironmentConfig}) => {
       // TODO 更改 dev
-      const mainConfig = Object.assign({}, defaultMainConfig, customMainConfig)
+      const mainConfig = Object.assign({}, defaultMainConfig, userMainConfig)
       return mergeEnvironmentConfig(config, mainConfig)
     })
   },

--- a/packages/plugin-preload/src/index.ts
+++ b/packages/plugin-preload/src/index.ts
@@ -1,6 +1,6 @@
 import type {EnvironmentConfig, RsbuildPlugin} from '@rsbuild/core'
 
-export const preloadConfig: EnvironmentConfig = {
+export const defaultPreloadConfig: EnvironmentConfig = {
   source: {
     entry: {
       index: './src/preload/index.ts',
@@ -26,10 +26,11 @@ export const preloadConfig: EnvironmentConfig = {
 /**
  * plugin-preload for rsbuild
  * */
-export const preloadPlugin = (): RsbuildPlugin => ({
+export const preloadPlugin = (customPreloadConfig?: EnvironmentConfig={}): RsbuildPlugin => ({
   name: 'electron-rsbuild:preload',
   setup(api) {
     api.modifyEnvironmentConfig((config, {mergeEnvironmentConfig}) => {
+      const preloadConfig = Object.assign({}, defaultPreloadConfig, customPreloadConfig)
       return mergeEnvironmentConfig(config, preloadConfig)
     })
   },

--- a/packages/plugin-preload/src/index.ts
+++ b/packages/plugin-preload/src/index.ts
@@ -26,11 +26,11 @@ export const defaultPreloadConfig: EnvironmentConfig = {
 /**
  * plugin-preload for rsbuild
  * */
-export const preloadPlugin = (customPreloadConfig?: EnvironmentConfig={}): RsbuildPlugin => ({
+export const preloadPlugin = (userPreloadConfig?: EnvironmentConfig={}): RsbuildPlugin => ({
   name: 'electron-rsbuild:preload',
   setup(api) {
     api.modifyEnvironmentConfig((config, {mergeEnvironmentConfig}) => {
-      const preloadConfig = Object.assign({}, defaultPreloadConfig, customPreloadConfig)
+      const preloadConfig = Object.assign({}, defaultPreloadConfig, userPreloadConfig)
       return mergeEnvironmentConfig(config, preloadConfig)
     })
   },

--- a/packages/plugin-renderer/src/index.ts
+++ b/packages/plugin-renderer/src/index.ts
@@ -25,12 +25,12 @@ export const defaultRendererConfig: EnvironmentConfig = {
 /**
  * plugin-renderer for rsbuild
  * */
-export const rendererPlugin = (customRendererConfig?: EnvironmentConfig={}): RsbuildPlugin => ({
+export const rendererPlugin = (userRendererConfig?: EnvironmentConfig={}): RsbuildPlugin => ({
   name: 'electron-rsbuild:renderer',
   pre: ['rsbuild:react'],
   setup(api) {
     api.modifyEnvironmentConfig((config, {mergeEnvironmentConfig}) => {
-      const rendererConfig = Object.assign({}, defaultRendererConfig, customRendererConfig)
+      const rendererConfig = Object.assign({}, defaultRendererConfig, userRendererConfig)
       return mergeEnvironmentConfig(config, rendererConfig)
     })
   },

--- a/packages/plugin-renderer/src/index.ts
+++ b/packages/plugin-renderer/src/index.ts
@@ -1,7 +1,7 @@
 import {resolve} from 'node:path'
 import type {EnvironmentConfig, RsbuildPlugin} from '@rsbuild/core'
 
-export const rendererConfig: EnvironmentConfig = {
+export const defaultRendererConfig: EnvironmentConfig = {
   html: {
     title: 'Electron-Rsbuild App',
   },
@@ -25,11 +25,12 @@ export const rendererConfig: EnvironmentConfig = {
 /**
  * plugin-renderer for rsbuild
  * */
-export const rendererPlugin = (): RsbuildPlugin => ({
+export const rendererPlugin = (customRendererConfig?: EnvironmentConfig={}): RsbuildPlugin => ({
   name: 'electron-rsbuild:renderer',
   pre: ['rsbuild:react'],
   setup(api) {
     api.modifyEnvironmentConfig((config, {mergeEnvironmentConfig}) => {
+      const rendererConfig = Object.assign({}, defaultRendererConfig, customRendererConfig)
       return mergeEnvironmentConfig(config, rendererConfig)
     })
   },


### PR DESCRIPTION
Hi there,  

I've recently been using this project to package desktop applications, but I found some of the plugins a bit inconvenient—especially their strict requirements regarding the directory structure. I checked the documentation but didn't find any way to modify these configurations, so I looked into the source code.  

I noticed that several plugins do not support users providing their own configuration, which seems a bit restrictive. I believe that users should not be forced to follow the project's default directory structure exactly. Instead, they should be able to provide custom configurations to adapt the plugins to their own project structure.  

Therefore, I modified these plugins to add a `customConfig` option, allowing users to inject their own configuration and make the plugins work with their directory layout.